### PR TITLE
fix(database): add Application to AutoMigrate to ensure table creation

### DIFF
--- a/pkg/database/db.go
+++ b/pkg/database/db.go
@@ -72,6 +72,7 @@ func Connection(uri string, shouldExist, debug bool) (*gorm.DB, error) {
 	if err := c.AutoMigrate(
 		&models.Result{},
 		&models.NetworkLog{},
+		&Application{}
 	); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This fix ensure application_info table is created during migrations

Before fix:
![image](https://github.com/user-attachments/assets/9145f48a-981b-478d-95fa-ca9a5cad5693)

After fix:
![image](https://github.com/user-attachments/assets/e08d47a3-c484-44c3-a7c8-25aa7db5eb43)
